### PR TITLE
[Issue-14] Duplicated class rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "a-touch-of-lilac-theme",
     "displayName": "A Touch of Lilac Theme",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "description": "Lilac tinted color UI theme with vibrant syntax highlighting colors for Visual Studio Code. It also has a No-Italics version.",
     "scripts": {
         "vsce:publish": "vsce publish"

--- a/themes/a-touch-of-lilac-no-italics.json
+++ b/themes/a-touch-of-lilac-no-italics.json
@@ -255,18 +255,10 @@
             }
         },
         {
-            "name": "Class name",
-            "scope": "entity.name.class",
-            "settings": {
-                "fontStyle": "underline",
-                "foreground": "#35ba66"
-            }
-        },
-        {
             "name": "Inherited class",
             "scope": "entity.other.inherited-class",
             "settings": {
-                "foreground": "#35ba66"
+                "foreground": "#b4df51"
             }
         },
         {

--- a/themes/a-touch-of-lilac.json
+++ b/themes/a-touch-of-lilac.json
@@ -255,18 +255,10 @@
             }
         },
         {
-            "name": "Class name",
-            "scope": "entity.name.class",
-            "settings": {
-                "fontStyle": "underline",
-                "foreground": "#35ba66"
-            }
-        },
-        {
             "name": "Inherited class",
             "scope": "entity.other.inherited-class",
             "settings": {
-                "foreground": "#35ba66"
+                "foreground": "#b4df51"
             }
         },
         {


### PR DESCRIPTION
Removed the duplicated "class name" rule, because the second one was inheriting from the first one a couple of unwanted styles